### PR TITLE
create ability to whitelist repos from CLA checks

### DIFF
--- a/osscla/services/gh.py
+++ b/osscla/services/gh.py
@@ -113,6 +113,18 @@ def update_pr_status(full_repo_name, pr_number):
     commits = pr.get_commits()
     authors = []
     author_without_login = False
+
+    # Automatically succeed with repos that have been whitelisted.
+    if full_repo_name in app.config['REPOS_WITH_WHITELISTED_CLA']:
+        last_commit = commits[0]
+        last_commit.create_status(
+            'success',
+            description='Whitelisted CLA.',
+            target_url=app.config['SITE_URL'],
+            context=app.config['GITHUB_STATUS_CONTEXT']
+        )
+        return
+
     for commit in commits:
         last_commit = commit
         try:

--- a/osscla/settings.py
+++ b/osscla/settings.py
@@ -51,6 +51,7 @@ def str_env(var_name, default=''):
     """
     return getenv(var_name, default)
 
+
 DEBUG = bool_env('DEBUG', False)
 if DEBUG:
     _DEFAULT_LOG_LEVEL = 'DEBUG'
@@ -151,6 +152,10 @@ WATCHED_ORGS = str_env('WATCHED_ORGS', '').split(',')
 WATCHED_ORGS_RELOAD_INTERVAL = int_env('WATCHED_ORGS_RELOAD_INTERVAL', 1860)
 # ORGS that have a Corporate CLA signed
 CCLA_ORGS = str_env('CCLA_ORGS', '').split(',')
+# A comma separated list of repos in the org that are whitelisted from CLA checks.
+# In other words, these repos will pass CLA checks automatically.
+REPOS_WITH_WHITELISTED_CLA = str_env(
+    'REPOS_WITH_WHITELISTED_CLA', '').split(',')
 
 # The DynamoDB table to use for storing PR references for CLA checks.
 # Example: mydynamodbtable-pr


### PR DESCRIPTION
This PR adds an app config option to whitelist repos from CLA checks based on the repo's name.

The whitelist causes every commit in whitelisted repos to automatically pass CLA checks regardless of CLA status of the committer. 