### PR TITLE
bump versions

### DIFF
--- a/piptools_requirements.txt
+++ b/piptools_requirements.txt
@@ -5,16 +5,17 @@
 #    control run piptools.compile osscla
 #
 appdirs==1.4.2
+asn1crypto==0.24.0        # via cryptography
 certifi==2017.1.23
 cffi==1.9.1               # via cryptography
-cryptography==1.7.1
+cryptography==2.7
 enum34==1.1.6             # via cryptography
 idna==2.2
 ipaddress==1.0.18         # via cryptography
 ndg-httpsclient==0.4.2
 pyasn1==0.1.9
 pycparser==2.17           # via cffi
-pyopenssl==16.2.0
+pyopenssl==19.0.0
 six==1.10.0               # via cryptography, pyopenssl
 
 pip==9.0.1

--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@
 # License: BSD
 # Upstream url: http://github.com/mitsuhiko/flask/
 # Use: For API.
-Flask==0.10.1
+Flask>=0.12.3
 
 # Flask Scripting support for Flask
 # License: BSD
@@ -76,3 +76,5 @@ PyGithub==1.35
 
 # Our unit testing framework
 pytest==2.8.5
+
+Pyopenssl>=17.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,17 +5,19 @@
 #    control run piptools.compile osscla
 #
 appdirs==1.4.2
+asn1crypto==0.24.0
 authomatic==0.1.0.post1
 boto3==1.4.4
 botocore==1.5.6           # via boto3, pynamodb, s3transfer
 certifi==2017.1.23
 cffi==1.9.1
-cryptography==1.7.1
+click==7.0                # via flask
+cryptography==2.7
 docutils==0.13.1          # via botocore
 enum34==1.1.6
 flask-script==2.0.5
 flask-sslify==0.1.5
-flask==0.10.1
+flask==1.1.1
 futures==3.1.1            # via s3transfer
 gevent==1.2.1
 greenlet==0.4.12
@@ -24,7 +26,7 @@ gunicorn==19.7.1
 idna==2.2
 ipaddress==1.0.18
 itsdangerous==0.24        # via flask
-jinja2==2.9.4             # via flask
+jinja2==2.10.1            # via flask
 jmespath==0.9.1           # via boto3, botocore
 markupsafe==0.23          # via jinja2
 ndg-httpsclient==0.4.2
@@ -34,13 +36,13 @@ pycparser==2.17
 pygithub==1.35
 pyjwt==1.5.2              # via pygithub
 pynamodb==3.0.1
-pyopenssl==16.2.0
+pyopenssl==19.0.0
 pytest==2.8.5
 python-dateutil==2.6.0
 s3transfer==0.1.10        # via boto3
 six==1.10.0
 statsd==3.2.1
-werkzeug==0.11.15         # via flask
+werkzeug==0.15.5          # via flask
 
 pip==9.0.1
 setuptools==40.8.0

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -5,31 +5,37 @@
 #    control run piptools.compile osscla
 #
 appdirs==1.4.2
+asn1crypto==0.24.0        # via cryptography
 authomatic==0.1.0.post1
 boto3==1.4.4
 botocore==1.5.6           # via boto3, pynamodb, s3transfer
+cffi==1.12.3              # via cryptography
+click==7.0                # via flask
+cryptography==2.7         # via pyopenssl
 docutils==0.13.1          # via botocore
 flask-script==2.0.5
 flask-sslify==0.1.5
-flask==0.10.1
+flask==1.1.1
 gevent==1.2.1
 greenlet==0.4.12
 guard==1.0.1
 gunicorn==19.7.1
 itsdangerous==0.24        # via flask
-jinja2==2.9.4             # via flask
+jinja2==2.10.1            # via flask
 jmespath==0.9.1           # via boto3, botocore
 markupsafe==0.23          # via jinja2
 py==1.4.32                # via pytest
+pycparser==2.19           # via cffi
 pygithub==1.35
 pyjwt==1.5.2              # via pygithub
 pynamodb==3.0.1
+pyopenssl==19.0.0
 pytest==2.8.5
 python-dateutil==2.6.0
 s3transfer==0.1.10        # via boto3
-six==1.10.0               # via pynamodb, python-dateutil
+six==1.10.0               # via cryptography, pynamodb, pyopenssl, python-dateutil
 statsd==3.2.1
-werkzeug==0.11.15         # via flask
+werkzeug==0.15.5          # via flask
 
 pip==9.0.1
 setuptools==40.8.0


### PR DESCRIPTION
https://jira.lyft.net/browse/INTPROD-2921

fixing bugs as part of the Lyft Bounty Hunters program during hackathon week 

note: it doesn't seem that pyopenssl is even used in this repo. it wasn't orignally in the `requirements.in` file, and instead, was only in `requirements.txt` and NOT in `requirements3.txt`. I checked the history, and it seems like this dependency was specified when the repo first first created. I do wonder whether we can just drop this, since I did a code search and it doesn't look like it's being used. But then again, I very much lack context, and I'm just here helping out via a small patch :D