### PR TITLE
require repo name and pr number to update pr status

### DIFF
--- a/osscla/services/gh.py
+++ b/osscla/services/gh.py
@@ -104,6 +104,13 @@ def _queue_repo_action(action, full_repo_name, pr_number):
 
 
 def update_pr_status(full_repo_name, pr_number):
+    if not full_repo_name:
+        logger.warning(f'Missing required full repo name to update PR #{pr_number} status')
+    if not pr_number:
+        logger.warning(f'Missing required pr number to update {full_repo_name} PR status')
+    if not full_repo_name or not pr_number:
+        return
+
     # We care about the author of all commits in the PR, so we'll find the
     # author of every commit, and ensure they have signatures.
     logger.debug(
@@ -170,9 +177,7 @@ def update_pr_status(full_repo_name, pr_number):
                     username=missing_author,
                     pr='{}:{}'.format(repo.full_name, pr_number)
                 )
-                _pr.save(
-                    pr__null=True
-                )
+                _pr.save()
                 logger.debug(
                     'Saved PR for missing author {}'.format(missing_author)
                 )


### PR DESCRIPTION
I don't believe this is a valid param in the save function anymore. It looks like null would have to be set on [the attribute](https://pynamodb.readthedocs.io/en/latest/tutorial.html?highlight=null#defining-model-attributes).

In. addition, I don't think there is a use case where we would want to try to update the PR status if either the repo name or PR number aren't set.